### PR TITLE
#163693714 Consume endpoint responsible for RSVP to a meetup

### DIFF
--- a/css/components/card.css
+++ b/css/components/card.css
@@ -19,6 +19,7 @@
 .questioner-card-description {
     margin-left: 20px;
     margin-bottom: 20px;
+    max-height: 8em;
     overflow: auto;
 }
 

--- a/css/styles.css
+++ b/css/styles.css
@@ -200,7 +200,7 @@ input:focus:valid {
 
 .questioner-card-row{
     margin-top: 7em;
-    margin-bottom: 5em;
+    margin-bottom: 5em;  
 
 }
 

--- a/explore.html
+++ b/explore.html
@@ -64,137 +64,18 @@
         <hr class="questioner-rule partial">
         <h2 class="questioner-center main-content-heading">EXPLORE </h2>
         <hr class="questioner-rule partial">
+        <div class="questioner-bar" id="response"></div>
+    </div>
+
+    <div id="exploremeetups">
+
+
+
     </div>
 
 
 
-    <div class="questioner-card-row">
-        <div class="questioner-column pad-bottom">
-            <div class="questioner-card-detail">
-                <div class="questioner-card">
-                    <span class="questioner-card-category">Nani Yokozuna</span>
-
-                    <img src="http://placehold.it/50x50" alt="" class="questioner-avatar-small questioner-card-image">
-                </div>
-                <div class="questioner-card-description">
-                    <h2 class="pad-left-half"><a href="details.html" class="questioner-explore-card" >National Heritage</a></h2>
-                    <p>Embracing culture and addressing misconceptions</p>
-                    <span class="questioner-span" id="venue"><i class="fa fa-map-marker"></i> Canivore, Langata</span>
-                    <br><br>
-                    <span class="questioner-span"> 14/02/19 </span>
-                    <span class="questioner-span">5:30 PM</span>
-
-                </div>
-
-                <button class="questioner-btn-transround" id="btn-attend">ATTENDING</button>
-            </div>
-        </div>
-        <div class="questioner-column">
-            <div class="questioner-card-detail">
-                <div class="questioner-card">
-                    <span class="questioner-card-category">Nani Yokozuna</span>
-
-                    <img src="http://placehold.it/50x50" alt="" class="questioner-avatar-small questioner-card-image">
-                </div>
-                <div class="questioner-card-description">
-                    <h2 class="pad-left-half">National Heritage</h2>
-                    <p>Embracing culture and addressing misconceptions</p>
-                    <span class="questioner-span" id="venue"><i class="fa fa-map-marker"></i> Canivore, Langata</span>
-                    <br><br>
-                    <span class="questioner-span"> 14/02/19 </span>
-                    <span class="questioner-span">5:30 PM</span>
-                </div>
-
-                <button class="questioner-btn-transround" id="btn-attend">ATTEND</button>
-            </div>
-
-        </div>
-        <div class="questioner-column">
-            <div class="questioner-card-detail">
-                <div class="questioner-card">
-                    <span class="questioner-card-category">Nani Yokozuna</span>
-
-                    <img src="http://placehold.it/50x50" alt="" class="questioner-avatar-small questioner-card-image">
-                </div>
-                <div class="questioner-card-description">
-                    <h2 class="pad-left-half">National Heritage</h2>
-                    <p>Embracing culture and addressing misconceptions</p>
-                    <span class="questioner-span" id="venue"><i class="fa fa-map-marker"></i> Canivore, Langata</span>
-                    <br><br>
-                    <span class="questioner-span"> 14/02/19 </span>
-                    <span class="questioner-span">5:30 PM</span>
-                </div>
-
-                <button class="questioner-btn-transround" id="btn-attend">ATTEND</button>
-            </div>
-
-        </div>
-    </div>
-
-    <div class="questioner-card-row" id="last-row">
-        <div class="questioner-column pad-bottom">
-            <div class="questioner-card-detail">
-                <div class="questioner-card">
-                    <span class="questioner-card-category">Nani Yokozuna</span>
-
-                    <img src="http://placehold.it/50x50" alt="" class="questioner-avatar-small questioner-card-image">
-                </div>
-                <div class="questioner-card-description">
-                    <h2 class="pad-left-half">National Heritage</h2>
-                    <p>Embracing culture and addressing misconceptions</p>
-                    <span class="questioner-span" id="venue"><i class="fa fa-map-marker"></i> Canivore, Langata</span>
-                    <br><br>
-                    <span class="questioner-span"> 14/02/19 </span>
-                    <span class="questioner-span">5:30 PM</span>
-                </div>
-
-                <button class="questioner-btn-transround" id="btn-attend">ATTEND</button>
-            </div>
-
-        </div>
-        <div class="questioner-column">
-            <div class="questioner-card-detail">
-                <div class="questioner-card">
-                    <span class="questioner-card-category">Nani Yokozuna</span>
-
-                    <img src="http://placehold.it/50x50" alt="" class="questioner-avatar-small questioner-card-image">
-                </div>
-                <div class="questioner-card-description">
-                    <h2 class="pad-left-half">National Heritage</h2>
-                    <p>Embracing culture and addressing misconceptions</p>
-                    <span class="questioner-span" id="venue"><i class="fa fa-map-marker"></i> Canivore, Langata</span>
-                    <br><br>
-                    <span class="questioner-span"> 14/02/19 </span>
-                    <span class="questioner-span">5:30 PM</span>
-                </div>
-
-                <button class="questioner-btn-transround" id="btn-attend">ATTEND</button>
-            </div>
-
-        </div>
-        <div class="questioner-column">
-            <div class="questioner-card-detail">
-                <div class="questioner-card">
-
-                    <span class="questioner-card-category">Nani Yokozuna</span>
-
-                    <img src="http://placehold.it/50x50" alt="" class="questioner-avatar-small questioner-card-image">
-                </div>
-                <div class="questioner-card-description">
-                    <h2 class="pad-left-half">National Heritage</h2>
-                    <p>Embracing culture and addressing misconceptions</p>
-                    <span class="questioner-span" id="venue"><i class="fa fa-map-marker"></i> Canivore, Langata</span>
-                    <br><br>
-                    <span class="questioner-span"> 14/02/19 </span>
-                    <span class="questioner-span">5:30 PM</span>
-                </div>
-                <button class="questioner-btn-transround" id="btn-attend">ATTEND</button>
-            </div>
-
-        </div>
-    </div>
-
-    <div class="questioner-pagination">
+    <div class="questioner-pagination" id="viewpagination">
         <div class="questioner-message">
             <div class="questioner-vote-div">
                 <i class="fa fa-angle-double-left icon-left"></i><i class="fa fa-angle-double-right icon-right"></i>
@@ -211,7 +92,7 @@
             <li><a href="#">Help</a></li>
         </ul>
     </footer>
-    <script src="js/main.js"></script>
+    <script src="js/explore.js"></script>
 </body>
 
 </html>

--- a/js/explore.js
+++ b/js/explore.js
@@ -1,0 +1,116 @@
+
+window.onload = function getMeetups(event) {
+  event.preventDefault();
+
+  fetch('https://questioner-apiv2-siffersari.herokuapp.com/api/v2/meetups/upcoming', {
+    method: 'GET',
+    headers: { 'Content-Type': 'application/json', Authorization: `Bearer ${localStorage.getItem('token')}` },
+  })
+    .then(async (resp) => {
+      if (resp.ok) {
+        const data = await resp.json();
+        const numberMeetups = data.data.length;
+        if (numberMeetups === 0) {
+          const responseDiv = document.getElementById('exploremeetups');
+          responseDiv.innerHTML = '<h2 class="top-response">No meetups found yet</h2>';
+          responseDiv.className += ' fluid';
+
+          const paginationdiv = document.getElementById('viewpagination');
+          paginationdiv.style.display = 'none';
+        } else {
+          let i = 0;
+          let result = '<div class="questioner-card-row">';
+          while (i < numberMeetups) {
+            if (i !== 0 && i % 3 === 0) {
+              result += '</div> <div class="questioner-card-row ">';
+            }
+            result += `
+          <div class="questioner-column pad-bottom">
+              <div class="questioner-card-detail">
+                  <div class="questioner-card">
+                      <span class="questioner-card-category">${data.data[i].createdBy}</span>
+
+                      <img src="http://placehold.it/50x50" alt="" class="questioner-avatar-small questioner-card-image">
+                  </div>
+                  <div class="questioner-card-description">
+                      <h2 class="pad-left-half"><a href="details.html" class="questioner-explore-card">${data.data[i].topic}</a></h2>
+                      <p></p>
+                      <span class="questioner-span" id="venue"><i class="fa fa-map-marker"></i> ${data.data[i].location} </span>
+                      <br><br>
+                      <span class="questioner-span"> ${data.data[i].happeningOn}</span>
+
+                  </div>
+
+                  <button class="questioner-btn-transround" id="btn-attend" onclick="attendMeetup(${data.data[i].id});">ATTEND</button>
+              </div>
+          </div>`;
+            i++;
+          }
+
+          result += '</div>';
+
+          document.getElementById('exploremeetups').innerHTML = result;
+        }
+      }
+      if (resp.status !== 200) {
+        const responseMessage = document.getElementById('response');
+        const dataOne = await resp.json();
+
+        if (JSON.stringify(dataOne.error).includes('expired')) {
+          responseMessage.innerHTML = 'Sorry this session has expired. Please log in to continue';
+
+          responseMessage.className += ' show';
+
+          setTimeout(() => {
+            responseMessage.className = responseMessage.className.replace('show', '');
+          }, 3000);
+          setTimeout(() => {
+            window.location.href = 'login.html';
+          }, 2000);
+        } else {
+          responseMessage.innerHTML = JSON.stringify(dataOne.error);
+
+          responseMessage.className += ' show';
+
+          setTimeout(() => {
+            responseMessage.className = responseMessage.className.replace('show', '');
+          }, 3000);
+        }
+      }
+    });
+};
+
+function attendMeetup(id) {
+  fetch(`https://questioner-apiv2-siffersari.herokuapp.com/api/v2/meetups/${id}/rsvps`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json', Authorization: `Bearer ${localStorage.getItem('token')}` },
+    body: JSON.stringify({
+      response: 'yes',
+    }),
+  })
+    .then(async (resp) => {
+      const responseMessage = document.getElementById('response');
+      if (resp.ok) {
+        const data = await resp.json();
+
+        responseMessage.innerHTML = 'Success';
+
+        responseMessage.className += ' show';
+
+        setTimeout(() => {
+          responseMessage.className = responseMessage.className.replace('show', '');
+        }, 3000);
+      }
+      if (resp.status !== 200) {
+        const dataOne = await resp.json();
+
+        responseMessage.innerHTML = JSON.stringify(dataOne.error);
+
+        responseMessage.className += ' show';
+
+        setTimeout(() => {
+          responseMessage.className = responseMessage.className.replace('show', '');
+        }, 3000);
+      }
+    });
+}


### PR DESCRIPTION
### What does this PR do ?
This pull request adds consumption of the endpoint that responds to a meetups attendance

### Description of tasks to be completed?

- Consume the API that is responsible for responding user's status on attendance to a meetup

### How should you manually test this?
Clone this repository in your working directory on your computer and navigate to Questioner-Ultimate directory
``` 
git clone https://github.com/Siffersari/Questioner-Ultimate.git

cd Questioner-Ultimate/UI

git checkout ft-consume-respondrsvp-163693714 branch

```
Open **explore.html** on your favorite browser 


### Prerequisites
 Git


### What are the relevant PT stories?
[#163693714](https://www.pivotaltracker.com/story/show/163693714)


### Screenshots
![screenshot from 2019-02-04 20-37-47](https://user-images.githubusercontent.com/33033576/52226029-e99f3a80-28bc-11e9-8898-8a3bddc89a38.png)

![screenshot_2019-02-04 questioner - explore meetups](https://user-images.githubusercontent.com/33033576/52226065-020f5500-28bd-11e9-8af9-720aab5fd389.png)
![screenshot_2019-02-04 questioner - explore meetups 1](https://user-images.githubusercontent.com/33033576/52226074-05a2dc00-28bd-11e9-835d-689aa1417d77.png)







