### PR TITLE
#163856147 Consume Endpoint responsible for viewing user profile

### DIFF
--- a/js/profile.js
+++ b/js/profile.js
@@ -1,0 +1,74 @@
+window.onload = function fetchProfile(event) {
+  event.preventDefault();
+
+
+  const url = 'https://questioner-apiv2-siffersari.herokuapp.com/api/v2/users';
+
+  fetch(url, {
+    method: 'GET',
+    headers: { 'Content-Type': 'application/json', Authorization: `Bearer ${localStorage.getItem('token')}` },
+  })
+    .then(async (resp) => {
+      if (resp.ok) {
+        const data = await resp.json();
+
+        const result = `<div class="questioner-product pad-top">
+
+        <img src="https://picsum.photos/300/300?image=0" alt="" class="questioner-product-image" id="profile">
+        <div class="questioner-product-description">
+            <h1 class="pad-left-half"> ${data.data[0].name}</h1>
+            <hr class="questioner-rule hang">
+            <br><br>
+            <span class="questioner-span" id="venue"> Member Since:</span>
+            <p>${data.data[0].registeredOn}</p>
+            <span class="questioner-span" id="venue">Email</span>
+            <p>${data.data[0].email}</p>
+            <span class="questioner-span" id="venue">Username</span>
+            <p>${data.data[0].username}</p>
+
+        </div>
+
+    </div>
+    <h2 class="questioner-center main-heading">MY STATS</h2>
+    <hr class="questioner-rule semi">
+    <div class="questioner-tabs questioner-margin">
+        <div class="questioner-tabs-item active" id="questioner-stats-tab">
+            <h3><a href="questions.html" class="questioner-anchor-button"> ${data.data[0].questions} </a></h3>
+            <p><a href="questions.html" class="questioner-anchor-button"> POSTED QUESTIONS </a> </p>
+        </div>
+        <div class="questioner-tabs-item" id="questioner-stats-tab">
+            <h3>${data.data[0].comments}</h3>
+            <p>COMMENTED QUESTIONS</p>
+        </div>
+
+    </div>`;
+
+        document.getElementById('profiledivision').innerHTML = result;
+      }
+      if (resp.status !== 200) {
+        const responseMessage = document.getElementById('response');
+        const dataOne = await resp.json();
+
+        if (JSON.stringify(dataOne.error).includes('expired') || JSON.stringify(dataOne.error).includes('valid')) {
+          responseMessage.innerHTML = 'Sorry this session has expired. Please log in to continue';
+
+          responseMessage.className += ' show';
+
+          setTimeout(() => {
+            responseMessage.className = responseMessage.className.replace('show', '');
+          }, 3000);
+          setTimeout(() => {
+            window.location.href = 'login.html';
+          }, 2000);
+        } else {
+          responseMessage.innerHTML = JSON.stringify(dataOne.error);
+
+          responseMessage.className += ' show';
+
+          setTimeout(() => {
+            responseMessage.className = responseMessage.className.replace('show', '');
+          }, 3000);
+        }
+      }
+    });
+};

--- a/profile.html
+++ b/profile.html
@@ -60,38 +60,10 @@
     </div>
     </div>
 
-    <div class="questioner-container fluid">
+    <div class="questioner-bar" id="response"></div>
 
-        <div class="questioner-product pad-top">
-
-            <img src="https://picsum.photos/300/300?image=0" alt="" class="questioner-product-image" id="profile">
-            <div class="questioner-product-description">
-                <h1 class="pad-left-half"> Nani Yokozuna</h1>
-                <hr class="questioner-rule hang">
-                <br><br>
-                <span class="questioner-span" id="venue"> Member Since:</span>
-                <p>2nd January, 2019</p>
-                <span class="questioner-span" id="venue">Email</span>
-                <p>Yokozunani@gmail.com</p>
-                <span class="questioner-span" id="venue">Username</span>
-                <p>Yokozunani</p>
-
-            </div>
-
-        </div>
-        <h2 class="questioner-center main-heading">MY STATS</h2>
-        <hr class="questioner-rule semi">
-        <div class="questioner-tabs questioner-margin">
-            <div class="questioner-tabs-item active" id="questioner-stats-tab">
-                <h3><a href="questions.html" class="questioner-anchor-button"> 90 </a></h3>
-                <p><a href="questions.html" class="questioner-anchor-button"> POSTED QUESTIONS </a> </p>
-            </div>
-            <div class="questioner-tabs-item" id="questioner-stats-tab">
-                <h3>65</h3>
-                <p>COMMENTED QUESTIONS</p>
-            </div>
-
-        </div>
+    <div class="questioner-container fluid" id="profiledivision">
+        
 
     </div>
 
@@ -105,7 +77,7 @@
     </footer>
 
 
-    <script src="js/main.js"></script>
+    <script src="js/profile.js"></script>
     <script src="js/logout.js"></script>
 </body>
 


### PR DESCRIPTION
### What does this PR do ?
This pull request adds consumption of the endpoint that fetches user details and statistics

### Description of tasks to be completed?

- Consume the API that is responsible for fetching user details and statistics

### How should you manually test this?
Clone this repository in your working directory on your computer and navigate to Questioner-Ultimate directory
``` 
git clone https://github.com/Siffersari/Questioner-Ultimate.git

cd Questioner-Ultimate/UI

git checkout ft-consume-viewprofile-163856147 branch

```
Open **profile** on your favorite browser  and interact with the UI


### Prerequisites
 Git


### What are the relevant PT stories?
[#163856147](https://www.pivotaltracker.com/story/show/163856147)


### Screenshots
**User 1**
![screenshot_2019-02-11 questioner - profile](https://user-images.githubusercontent.com/33033576/52581905-fa136000-2e3c-11e9-9597-aee21eddd68e.png)
**User 2**
![screenshot_2019-02-11 questioner - profile 1](https://user-images.githubusercontent.com/33033576/52581906-fbdd2380-2e3c-11e9-8519-9b1f5a04f68b.png)
**Mobile view**
![screenshot_2019-02-11 questioner - profile 2](https://user-images.githubusercontent.com/33033576/52581955-19aa8880-2e3d-11e9-9bca-a5ca6bf5bcae.png)






